### PR TITLE
support hadoop 3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <project.build.targetJdk>1.8</project.build.targetJdk>
         <shadeBase>io.trino.hadoop.\$internal</shadeBase>
         <dep.slf4j.version>1.7.25</dep.slf4j.version>
-        <dep.hadoop.version>3.2.0</dep.hadoop.version>
+        <dep.hadoop.version>3.2.2</dep.hadoop.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -520,6 +520,26 @@
                                     <shadedPattern>${shadeBase}.com.google.re2j</shadedPattern>
                                 </relocation>
                                 <relocation>
+                                    <pattern>com.google.errorprone</pattern>
+                                    <shadedPattern>${shadeBase}.com.google.errorprone</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google.j2objc</pattern>
+                                    <shadedPattern>${shadeBase}.com.google.j2objc</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google.thirdparty</pattern>
+                                    <shadedPattern>${shadeBase}.com.google.thirdparty</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.checkerframework</pattern>
+                                    <shadedPattern>${shadeBase}.org.checkerframework</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.codehaus</pattern>
+                                    <shadedPattern>${shadeBase}.org.codehaus</shadedPattern>
+                                </relocation>
+                                <relocation>
                                     <pattern>com.fasterxml.jackson</pattern>
                                     <shadedPattern>${shadeBase}.com.fasterxml.jackson</shadedPattern>
                                 </relocation>

--- a/pom.xml
+++ b/pom.xml
@@ -548,6 +548,10 @@
                                     <shadedPattern>${shadeBase}.org.codehaus.jackson</shadedPattern>
                                 </relocation>
                                 <relocation>
+                                    <pattern>org.codehaus.mojo</pattern>
+                                    <shadedPattern>${shadeBase}.org.codehaus.mojo</shadedPattern>
+                                </relocation>
+                                <relocation>
                                     <pattern>com.ctc.wstx</pattern>
                                     <shadedPattern>${shadeBase}.com.ctc.wstx</shadedPattern>
                                 </relocation>

--- a/src/main/java/io/trino/hadoop/SocksSocketFactory.java
+++ b/src/main/java/io/trino/hadoop/SocksSocketFactory.java
@@ -112,7 +112,7 @@ public class SocksSocketFactory
                     throws IOException
             {
                 try {
-                    SocketAddress address = new InetSocketAddress(InetAddress.getByName(proxy.getHostText()), proxy.getPort());
+                    SocketAddress address = new InetSocketAddress(InetAddress.getByName(proxy.getHost()), proxy.getPort());
                     socket.connect(address, timeout);
                 }
                 catch (IOException e) {


### PR DESCRIPTION
Since hadoop 3.2.2, ObserverNameNode is supported. (https://hadoop.apache.org/docs/r3.2.2/hadoop-project-dist/hadoop-hdfs/ObserverNameNode.html)

Because Trino is using hadoop 3.2.0, If Trino is used in the 3.2.2, the following error will occur.

-----------------
SQL Error [16777232]: Query failed (#...): Couldn't create proxy provider class org.apache.hadoop.hdfs.server.namenode.ha.ObserverReadProxyProvider
-----------------

If Trino upgrade to 3.2.2, I don't know what side effects there might be. But in my environment, I didn't find the problem.

The referenced guava :11.0.2 has been updated to 27.0-jre .
So I changed the depredicated com.google.common.net.HostAndPort.getHostPort to getHost.