### PR TITLE
Fix the VersionedFileStatus comparison in AzureBlobFileSystemStore

### DIFF
--- a/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -988,7 +988,7 @@ public class AzureBlobFileSystemStore {
 
             FileStatus other = (FileStatus) obj;
 
-            if (!other.equals(this)) {// compare the path
+            if (!this.getPath().equals(other.getPath())) {
                 return false;
             }
 


### PR DESCRIPTION
Use the actual path in comparision than calling the `equals` again
which results in infinite recusion (ultimately stack overflow error)

This is fixed as part of HADOOP-16269 (PR hadoop#768)