### PR TITLE
Wrap for LocalFileSystem if needed

### DIFF
--- a/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -432,7 +432,7 @@ public abstract class FileSystem extends Configured
    */
   public static LocalFileSystem getLocal(Configuration conf)
     throws IOException {
-    return (LocalFileSystem)get(LocalFileSystem.NAME, conf);
+    return ensureLocalFileSystem(get(LocalFileSystem.NAME, conf));
   }
 
   /**
@@ -552,7 +552,14 @@ public abstract class FileSystem extends Configured
    */
   public static LocalFileSystem newInstanceLocal(Configuration conf)
     throws IOException {
-    return (LocalFileSystem)newInstance(LocalFileSystem.NAME, conf);
+    return ensureLocalFileSystem(newInstance(LocalFileSystem.NAME, conf));
+  }
+
+  private static LocalFileSystem ensureLocalFileSystem(FileSystem fileSystem) {
+    if (fileSystem instanceof LocalFileSystem) {
+      return (LocalFileSystem) fileSystem;
+    }
+    return new LocalFileSystemWrapper(fileSystem);
   }
 
   /**

--- a/src/main/java/org/apache/hadoop/fs/LocalFileSystemWrapper.java
+++ b/src/main/java/org/apache/hadoop/fs/LocalFileSystemWrapper.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs;
+
+class LocalFileSystemWrapper extends LocalFileSystem {
+    LocalFileSystemWrapper(FileSystem rawLocalFileSystem) {
+        super(rawLocalFileSystem);
+    }
+}


### PR DESCRIPTION
After modifying the cache implementation, the output FileSystem of `FileSystem#getLocal` may not be cast to LocalFileSystem, so wrap it if needed.

Fixes trinodb/trino#10306