### PR TITLE
Remove unnecessary synchronization in ForwardingFileSystemCache

### DIFF
--- a/src/main/java/org/apache/hadoop/fs/ForwardingFileSystemCache.java
+++ b/src/main/java/org/apache/hadoop/fs/ForwardingFileSystemCache.java
@@ -46,7 +46,7 @@ final class ForwardingFileSystemCache
     }
 
     @Override
-    synchronized void remove(Key ignored, FileSystem fileSystem)
+    void remove(Key ignored, FileSystem fileSystem)
     {
         if (fileSystem == null) {
             return;
@@ -55,20 +55,20 @@ final class ForwardingFileSystemCache
     }
 
     @Override
-    synchronized void closeAll()
+    void closeAll()
             throws IOException
     {
         cache.closeAll();
     }
 
     @Override
-    synchronized void closeAll(boolean onlyAutomatic)
+    void closeAll(boolean onlyAutomatic)
     {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    synchronized void closeAll(UserGroupInformation ugi)
+    void closeAll(UserGroupInformation ugi)
     {
         throw new UnsupportedOperationException();
     }


### PR DESCRIPTION
We have a custom implementation of `FileSystem` class in our HDFS storage layer internally, and one of the attempted enhancements to this custom `FileSystem` class has resulted in deadlock between two classes in Trino code base - `ForwardingFileSystemCache` and `TrinoFileSystemCache`. The enhancement involves invoking `FileSystem.close()` on a nested filesystem object as part of initializing the top level `CustomFileSystem` object as shown below.
```
TrinoFileSystemCache.get() -> {
  synchronized TrinoFileSystemCache.getInternal() -> {
    TrinoFileSystemCache.createFileSystem() ->
      CustomFileSystem.initialize() -> {
        ...
        DistributedFileSystem.initialize() ->
        DistributedFileSystem.open() ->
        DistributedFileSystem.close() ->  // Triggers synchronized ForwardingFileSystemCache.remove()
        ...
      }
    ...
  }
}
```

This has resulted in deadlock in our internal Trino codebase, and can be reproduced using the unit test provided below together with minor changes to `TrinoFileSysyemCache`-
1. Rough code changes to simulate the `FileSystem.close()` call from inside the lock in `TrinoFileSystemCache.getInternal()` is below. Note that the code below is similar to [FileSystem.Cache.getInternal() impl](https://github.com/apache/hadoop/blob/release-3.2.0-RC1/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java#L3356) where `createFileSystem()` is invoked outside of the lock, and then the newly created filesystem object is discarded if another filesystem object already exist in the map for the key after acquiring the lock.
```
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/TrinoFileSystemCache.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/TrinoFileSystemCache.java
@@ -91,7 +91,7 @@ public class TrinoFileSystemCache
         return getInternal(uri, conf, unique.incrementAndGet());
     }

-    private synchronized FileSystem getInternal(URI uri, Configuration conf, long unique)
+    private FileSystem getInternal(URI uri, Configuration conf, long unique)
             throws IOException
     {
         UserGroupInformation userGroupInformation = UserGroupInformation.getCurrentUser();
@@ -99,15 +99,26 @@ public class TrinoFileSystemCache
         FileSystemKey key = createFileSystemKey(uri, userGroupInformation, unique, conf.getBoolean(DFSAuthConfigKeys.DFS_AUTH_TOKEN_REQUEST_ENABLED, false));
         Set<?> privateCredentials = getPrivateCredentials(userGroupInformation);

-        FileSystemHolder fileSystemHolder = map.get(key);
+        FileSystemHolder fileSystemHolder;
+        synchronized (this) {
+            fileSystemHolder = map.get(key);
+        }
         if (fileSystemHolder == null) {
-            int maxSize = conf.getInt("fs.cache.max-size", 1000);
-            if (map.size() >= maxSize) {
-                throw new IOException(format("FileSystem max cache size has been reached: %s", maxSize));
-            }
             FileSystem fileSystem = createFileSystem(uri, conf);
-            fileSystemHolder = new FileSystemHolder(fileSystem, privateCredentials);
-            map.put(key, fileSystemHolder);
+            synchronized (this) {
+                int maxSize = conf.getInt("fs.cache.max-size", 1000);
+                if (map.size() >= maxSize) {
+                    throw new IOException(format("FileSystem max cache size has been reached: %s", maxSize));
+                }
+                fileSystemHolder = map.get(key);
+                if (fileSystemHolder == null) {
+                    fileSystemHolder = new FileSystemHolder(fileSystem, privateCredentials);
+                    map.put(key, fileSystemHolder);
+                }
+                else {
+                    fileSystem.close();    // this can trigger deadlock
+                }
+            }
         }
```

2. Unit test to simulate the deadlock -
```
--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestFileSystemCache.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestFileSystemCache.java
@@ -24,7 +24,15 @@ import org.apache.hadoop.fs.Path;
 import org.testng.annotations.Test;

 import java.io.IOException;
-
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotSame;
 import static org.testng.Assert.assertSame;

@@ -83,6 +91,43 @@ public class TestFileSystemCache
         assertNotSame(fs5, fs6);
     }

+    @Test(enabled = true)
+    public void testFileSystemCacheDeadlock() throws IOException, InterruptedException, ExecutionException
+    {
+        HdfsEnvironment environment = new HdfsEnvironment(
+                new HiveHdfsConfiguration(new HdfsConfigurationInitializer(new HdfsConfig()), ImmutableSet.of()),
+                new HdfsConfig(),
+                new ImpersonatingHdfsAuthentication(new SimpleHadoopAuthentication()));
+
+        // A task that creates and closes filesystem objects 1000 times
+        Callable<String> task = () -> {
+            try {
+                for (int i = 0; i < 1000; ++i) {
+                    FileSystem fs = getFileSystem(environment, "user" + String.valueOf(i));
+                    fs.close();
+                }
+                return "Success";
+            }
+            catch (IOException e) {
+                e.printStackTrace();
+                return "Failed";
+            }
+        };
+        List<Callable<String>> callableTasks = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            callableTasks.add(task);
+        }
+
+        // Thread pool that runs 10 such tasks concurrently to trigger deadlock
+        ExecutorService executor = Executors.newFixedThreadPool(10);
+        List<Future<String>> futures = executor.invokeAll(callableTasks);
+        for (Future<String> fut : futures) {
+            System.out.println(fut.get());
+            assertEquals("Success", fut.get());
+        }
+        FileSystem.closeAll();
+    }
+
```

Above unit test was run on a 4 core hyper threaded node, and a deadlock resulted immediately-`./mvnw test -pl 'plugin/trino-hive' -Dtest=io.trino.plugin.hive.TestFileSystemCache#testFileSystemCacheDeadlock`

Below are the stack traces of the 2 threads that deadlocked (using jstack) -
```
"pool-3-thread-1":
        at org.apache.hadoop.fs.ForwardingFileSystemCache.remove(ForwardingFileSystemCache.java:51)
        - waiting to lock <0x00000007fb206a70> (a org.apache.hadoop.fs.ForwardingFileSystemCache)
        at org.apache.hadoop.fs.FileSystem.close(FileSystem.java:2427)
        at org.apache.hadoop.fs.RawLocalFileSystem.close(RawLocalFileSystem.java:611)
        at org.apache.hadoop.fs.FilterFileSystem.close(FilterFileSystem.java:514)
        at org.apache.hadoop.fs.FilterFileSystem.close(FilterFileSystem.java:514)
        at io.trino.plugin.hive.fs.TrinoFileSystemCache.getInternal(TrinoFileSystemCache.java:119)
        - locked <0x00000007fb206988> (a io.trino.plugin.hive.fs.TrinoFileSystemCache)
        at io.trino.plugin.hive.fs.TrinoFileSystemCache.get(TrinoFileSystemCache.java:84)
        at org.apache.hadoop.fs.ForwardingFileSystemCache.get(ForwardingFileSystemCache.java:38)
        at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:475)
        at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:228)
        at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:459)
        at org.apache.hadoop.fs.Path.getFileSystem(Path.java:356)
        at io.trino.plugin.hive.HdfsEnvironment.lambda$getFileSystem$0(HdfsEnvironment.java:82)
        at io.trino.plugin.hive.HdfsEnvironment$$Lambda$94/0x00000008001ab440.run(Unknown Source)
        at io.trino.plugin.hive.authentication.UserGroupInformationUtils.lambda$executeActionInDoAs$0(UserGroupInformationUtils.java:29)
        at io.trino.plugin.hive.authentication.UserGroupInformationUtils$$Lambda$111/0x0000000800207040.run(Unknown Source)
        at java.security.AccessController.doPrivileged(java.base@11.0.8/Native Method)
        at javax.security.auth.Subject.doAs(java.base@11.0.8/Subject.java:361)
        at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1873)
        at io.trino.plugin.hive.authentication.UserGroupInformationUtils.executeActionInDoAs(UserGroupInformationUtils.java:27)
        at io.trino.plugin.hive.authentication.ImpersonatingHdfsAuthentication.doAs(ImpersonatingHdfsAuthentication.java:39)
        at io.trino.plugin.hive.HdfsEnvironment.getFileSystem(HdfsEnvironment.java:81)
        at io.trino.plugin.hive.TestFileSystemCache.getFileSystem(TestFileSystemCache.java:140)
        at io.trino.plugin.hive.TestFileSystemCache.lambda$testFileSystemCacheDeadlock$0(TestFileSystemCache.java:104)
        at io.trino.plugin.hive.TestFileSystemCache$$Lambda$93/0x0000000800139c40.call(Unknown Source)
        at java.util.concurrent.FutureTask.run(java.base@11.0.8/FutureTask.java:264)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.8/ThreadPoolExecutor.java:1128)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.8/ThreadPoolExecutor.java:628)
        at java.lang.Thread.run(java.base@11.0.8/Thread.java:834)

"pool-3-thread-3":
        at io.trino.plugin.hive.fs.TrinoFileSystemCache.remove(TrinoFileSystemCache.java:181)
        - waiting to lock <0x00000007fb206988> (a io.trino.plugin.hive.fs.TrinoFileSystemCache)
        at org.apache.hadoop.fs.ForwardingFileSystemCache.remove(ForwardingFileSystemCache.java:54)
        - locked <0x00000007fb206a70> (a org.apache.hadoop.fs.ForwardingFileSystemCache)
        at org.apache.hadoop.fs.FileSystem.close(FileSystem.java:2427)
        at org.apache.hadoop.fs.FilterFileSystem.close(FilterFileSystem.java:513)
        at io.trino.plugin.hive.TestFileSystemCache.lambda$testFileSystemCacheDeadlock$0(TestFileSystemCache.java:105)
        at io.trino.plugin.hive.TestFileSystemCache$$Lambda$93/0x0000000800139c40.call(Unknown Source)
        at java.util.concurrent.FutureTask.run(java.base@11.0.8/FutureTask.java:264)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.8/ThreadPoolExecutor.java:1128)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.8/ThreadPoolExecutor.java:628)
        at java.lang.Thread.run(java.base@11.0.8/Thread.java:834)
```

Looking at the section of code that resulted in this deadlock, observed that we are unnecessarily synchronizing methods in `ForwardingFileSystemCache` - as there is no data element that needs to be synchronized in this class. We already have required synchronization available in `TrinoFileSystemCache` class.

Removing this synchronization from `ForwardingFileSystemCache` removes the the deadlock captured in the above unit test.